### PR TITLE
Add back the product to the pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<modules>
 		<module>com.aobuchow.themes.moderndark</module>
 		<module>com.aobuchow.themes.moderndark.feature</module>
+		<module>com.aobuchow.themes.moderndark.product</module>
 		<module>releng-updatesite</module>
 	</modules>
 


### PR DESCRIPTION
The missing product was causing the plugin install to give an error.

The error was:
```
An error occurred while collecting items to be installed
session context was:(profile=SDKProfile, phase=org.eclipse.equinox.internal.p2.engine.phases.Collect, operand=, action=).
No repository found containing: osgi.bundle,com.aobuchow.themes.moderndark,1.0.5.202006100539
No repository found containing: org.eclipse.update.feature,com.aobuchow.themes.moderndark.feature,1.0.5.202006100539
```

Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>